### PR TITLE
Fix series poster XML name

### DIFF
--- a/tvdb.go
+++ b/tvdb.go
@@ -270,7 +270,7 @@ type Series struct {
 	Added         dateTime    `xml:"added"`
 	AddedBy       nullInt     `xml:"addedBy"`
 	FanartPath    string      `xml:"fanart"`
-	PostersPath   string      `xml:"posters"`
+	PostersPath   string      `xml:"poster"`
 	LastUpdated   unixTime    `xml:"lastupdated"`
 }
 


### PR DESCRIPTION
The TVDB API is using `poster` instead of `posters` for their series poster XML element, causing `PostersPath` to turn up as an empty string in the `Series` Go struct.